### PR TITLE
Fix for Get-SCTenantEvent and Get-SCTenantServiceInfo

### DIFF
--- a/O365ServiceCommunications/functions/Get-SCTenantEvent.ps1
+++ b/O365ServiceCommunications/functions/Get-SCTenantEvent.ps1
@@ -36,6 +36,7 @@ function Get-SCTenantEvent
         pastDays            = $PastDays
     }
 
+    #$ServiceUrl being loaded from /helpers/Config.ps1
     $Splat = @{
         ContentType = 'application/json'
         Method      = 'Post'
@@ -51,10 +52,10 @@ function Get-SCTenantEvent
 		foreach ($EventType in $EventTypes)
 		{
 			$Body.preferredEventTypes = @($EventCodes.$EventType)
-			$Splat.Body = $Body | ConvertTo-Json
-
-			Invoke-RestMethod @Splat | Select-Object -ExpandProperty Events |
-			New-CustomObject -Typename $TenantEventTypeName -ExtraProperties @{EventType = $EventType; TenantDomain = $Domain}
+            $Splat.Body = $Body | ConvertTo-Json
+            
+			Invoke-RestMethod @splat | Select-Object -ExpandProperty EventsByTenantDomain | Select-Object -ExpandProperty Value |
+            New-CustomObject -Typename $TenantEventTypeName -ExtraProperties @{EventType = $EventType; TenantDomain = $Domain}
 		}
 	}
 }

--- a/O365ServiceCommunications/functions/Get-SCTenantServiceInfo.ps1
+++ b/O365ServiceCommunications/functions/Get-SCTenantServiceInfo.ps1
@@ -12,10 +12,12 @@ function Get-SCTenantServiceInfo
 		$Domains
     )
 
+    #Documentation says: lastCookie, locale, companydomains. This is wrong.
+    #Working JSON Body: lastCookie, locale, tenantDomains
     $Body = @{
         lastCookie = $SCSession.Cookie
         locale     = $SCSession.Locale
-		companyDomains = @($Domains)
+		tenantDomains = @($Domains)
     }
 
     $Splat = @{
@@ -25,7 +27,7 @@ function Get-SCTenantServiceInfo
 		Body        = $Body | ConvertTo-Json
     }
 
-	Invoke-RestMethod @Splat | foreach {
+	Invoke-RestMethod @Splat | Foreach-Object {
 		$_ | New-CustomObject -TypeName $TenantServiceInfoTypeName
 	}
 }


### PR DESCRIPTION
Fixing #5 , allowing the use of  Get-SCTenantEvent and Get-SCTenantServiceInfo with an Input String Array of Partner Tenant Domains.

Microsoft API Documentation at https://msdn.microsoft.com/en-us/library/office/dn776043.aspx seems wrong for GetServiceInformationForTenantDomains as they document the JSON Body to be 
```
""lastCookie":"","companydomains":[],"locale":"" 
```
while in fact it should be
```
""lastCookie":"","tenantDomains":[],"locale":"" 
```